### PR TITLE
0.0.11: dyalogEnvVars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+## 0.0.11
+- new setting "dyalogEnvVars" to set up environment variables that get passed to the interpreter
 
 ## 0.0.10
 - update dependencies

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This extension has the configuration options listed below:
     "apl.server.executablePath": "dyalog.exe",
     "apl.server.maxWS": "4G",
     "apl.server.prefixCompleteCharacters": "`",
-    "apl.server.wsPath": "/my/own/apl-language-server.dws"
+    "apl.server.wsPath": "/my/own/apl-language-server.dws",
+    "apl.server.dyalogEnvVars": {}
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
 					"default": null,
 					"description": "The full path to a Dyalog executable (including the name of the binary)."
 				},
+				"apl.server.dyalogEnvVars": {
+					"type": "object",
+					"default": null,
+					"description": "Optional environment variables for the interpreter's environment (might be used for configuration)"
+				},
 				"apl.server.wsPath": {
 					"type": [
 						"string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT License. See License.txt in the project root for license information.
+* ------------------------------------------------------------------------------------------ */
 'use strict';
 
 import {
@@ -44,6 +44,7 @@ export async function activate(context: ExtensionContext) {
 
 	const serverPath = conf.get<string>('wsPath') || 
 		context.asAbsolutePath(path.join('server', 'apl-language-server.dws'));
+		const dyalogEnvVars = conf.get('dyalogEnvVars');
 
 	const serverOptions = () => new Promise<ChildProcess | StreamInfo>((resolve) => {
 		// Use a TCP socket because of problems with blocking STDIO
@@ -87,6 +88,7 @@ export async function activate(context: ExtensionContext) {
 							AUTOCOMPLETE_PREFIXSIZE: 0,
 							LSP_TCP: hp,
 						},
+						dyalogEnvVars,  // these will override the previous defaults
 					),
 				},
 			);


### PR DESCRIPTION
Adds option to set environment variables for the interpreter that runs the language server. (My use case: I have log_file configured as "./foo_180u64.dlf" - that causes problems when closing the extension as the log-file would be written in the VS Code Folder in %ProgramFiles%. This change enabled me to add "dyalogEnvVars":{"log_file":"/temp/vcs_180u64.dlf"} - problem solved. 